### PR TITLE
fix: improve gitignore and enable HTML report in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
           echo "✅ CI environment file created"
 
       - name: 🧪 Run Playwright tests
-        run: ENV=ci npx playwright test --project=chromium --reporter=list
+        run: ENV=ci npx playwright test --project=chromium --reporter=list,html
 
       - name: 📸 Upload test-results (screenshots/videos)
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ reports/
 # Environment files
 .env
 .env.*
+.env.ci
+.env.prod
 .DS_Store


### PR DESCRIPTION
- Add explicit .env.ci and .env.prod to gitignore
- Enable HTML reporter in CI workflow to generate playwright-report
- This fixes the warning about missing playwright-report/ directory